### PR TITLE
Make fill configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ A **typical workflow** looks as follows:
 * **`type TUR_Cap = 'butt'|'round'|'square'`**<br>represents a line end type
 * **`type TUR_PathOptionSet = {`**<br>
   &nbsp; **`x?:TUR_Location, y?:TUR_Location, Direction?:TUR_Angle,`**<br>
-  &nbsp; **`Width?:TUR_Dimension, Color?:TUR_Color,`**<br>
+  &nbsp; **`Width?:TUR_Dimension, Color?:TUR_Color, Fill?:TUR_Color,`**<br>
   &nbsp; **`Lineature?:TUR_Lineature, Join?:TUR_Join, Cap?:TUR_Cap`**<br>
   **`}`**<br>represents a set of options which may be used to initialize a new path
 * **`type TUR_Position = { x:TUR_Location, y:TUR_Location }`**<br>represents a position of the turtle, given by its x and y coordinates - but whithout specifying its orientation
@@ -123,6 +123,7 @@ Class `Graphic` has a single parameterless constructor. After instantiation (or,
 * `Direction`: `0` (in direction of the x-axis)<br>&nbsp;
 * `Width`: 1
 * `Color`: `#000000`
+* `Fill`: `none`
 * `Lineature`: `solid`
 * `Join`: `round`
 * `Cap`: `round`

--- a/src/svg-turtle.ts
+++ b/src/svg-turtle.ts
@@ -26,7 +26,7 @@
 
   export type TUR_PathOptionSet = {
     x?:TUR_Location, y?:TUR_Location, Direction?:TUR_Angle,
-    Width?:TUR_Dimension, Color?:TUR_Color,
+    Width?:TUR_Dimension, Color?:TUR_Color, Fill?:TUR_Color,
     Lineature?:TUR_Lineature, Join?:TUR_Join, Cap?:TUR_Cap
   }
 
@@ -89,6 +89,7 @@
       ((Value.Direction == null) || ValueIsFiniteNumber(Value.Direction)) &&
       ((Value.Width == null)     || ValueIsNumberInRange(Value.Width, 0)) &&
       ((Value.Color == null)     || ValueIsColor(Value.Color)) &&
+      ((Value.Fill == null)      || ValueIsColor(Value.Fill)) &&
       ((Value.Lineature == null) || ValueIsOneOf(Value.Lineature,TUR_Lineatures)) &&
       ((Value.Join == null)      || ValueIsOneOf(Value.Join,TUR_Joins)) &&
       ((Value.Cap == null)       || ValueIsOneOf(Value.Cap,TUR_Caps))
@@ -120,6 +121,7 @@
 
     private currentWidth:TUR_Dimension     = 1
     private currentColor:TUR_Color         = '#000000'
+    private currentFill:TUR_Color          = 'none'
     private currentLineature:TUR_Lineature = 'solid'
     private currentJoin:TUR_Join           = 'round'
     private currentCap:TUR_Cap             = 'round'
@@ -133,6 +135,7 @@
 
       if (this.currentWidth     == null) { this.currentWidth     = 1 }
       if (this.currentColor     == null) { this.currentColor     = '#000000' }
+      if (this.currentFill      == null) { this.currentFill      = 'none' }
       if (this.currentLineature == null) { this.currentLineature = 'solid' }
       if (this.currentJoin      == null) { this.currentJoin      = 'round' }
       if (this.currentCap       == null) { this.currentCap       = 'round' }
@@ -147,6 +150,7 @@
 
       this.currentWidth     = 1
       this.currentColor     = '#000000'
+      this.currentFill      = 'none'
       this.currentLineature = 'solid'
       this.currentJoin      = 'round'
       this.currentCap       = 'round'
@@ -171,6 +175,7 @@
         if (PathOptionSet.Direction != null) { this.currentDirection = PathOptionSet.Direction as TUR_Angle }
         if (PathOptionSet.Width     != null) { this.currentWidth     = PathOptionSet.Width as TUR_Dimension }
         if (PathOptionSet.Color     != null) { this.currentColor     = PathOptionSet.Color as TUR_Color }
+        if (PathOptionSet.Fill      != null) { this.currentFill      = PathOptionSet.Fill as TUR_Color }
         if (PathOptionSet.Lineature != null) { this.currentLineature = PathOptionSet.Lineature as TUR_Lineature }
         if (PathOptionSet.Join      != null) { this.currentJoin      = PathOptionSet.Join as TUR_Join }
         if (PathOptionSet.Cap       != null) { this.currentCap       = PathOptionSet.Cap as TUR_Cap }
@@ -182,7 +187,7 @@
       }
 
       this.currentPath = '<path ' +
-        'fill="none" ' +
+        'fill="'            + this.currentFill  + '" ' +
         'stroke="'          + this.currentColor + '" ' +
         'stroke-width="'    + this.currentWidth + '" ' +
         'stroke-linejoin="' + this.currentJoin  + '" ' +


### PR DESCRIPTION
Thanks for this neat library!

I'm drawing shapes and would like to set the `fill` attribute on the generated `<path>` elements. I've added support for this. It should be backwards compatible.

Would you consider merging and making a new release?

Thanks!